### PR TITLE
Fix the exception thrown when the plugin is disabled due to the temp directory not created

### DIFF
--- a/src/main/java/live/minehub/polarpaper/PolarPaper.java
+++ b/src/main/java/live/minehub/polarpaper/PolarPaper.java
@@ -75,11 +75,15 @@ public final class PolarPaper extends JavaPlugin {
         getLogger().info("Clearing temp directory");
         Path pluginFolder = Path.of(getDataFolder().getAbsolutePath());
         Path tempFolder = pluginFolder.resolve("temp");
-        try (Stream<Path> paths = Files.walk(tempFolder)) {
-            paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-        } catch (IOException e) {
-            getLogger().warning("Failed to delete temp directory");
-            getLogger().log(Level.INFO, e.getMessage(), e);
+        if (Files.exists(tempFolder)) {
+            try (Stream<Path> paths = Files.walk(tempFolder)) {
+                paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            } catch (IOException e) {
+                getLogger().warning("Failed to delete temp directory");
+                getLogger().log(Level.INFO, e.getMessage(), e);
+            }
+        } else {
+            getLogger().log(Level.INFO, "Temp directory does not exist. Skipping...");
         }
 
         for (World world : getServer().getWorlds()) {


### PR DESCRIPTION
Sometimes on server stopping this exception is thown:
<details><summary>Log</summary>
<p>

[**:**:**] [Server thread/WARN]: [polarpaper] Failed to delete temp directory
[**:**:**] [Server thread/INFO]: [polarpaper] /path/to/server/plugins/polarpaper/temp
java.nio.file.NoSuchFileException: /path/to/server/plugins/polarpaper/temp
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[?:?]
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106) ~[?:?]
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
	at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55) ~[?:?]
	at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:171) ~[?:?]
	at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99) ~[?:?]
	at java.base/java.nio.file.Files.readAttributes(Files.java:1854) ~[?:?]
	at java.base/java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:220) ~[?:?]
	at java.base/java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:277) ~[?:?]
	at java.base/java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:323) ~[?:?]
	at java.base/java.nio.file.FileTreeIterator.<init>(FileTreeIterator.java:71) ~[?:?]
	at java.base/java.nio.file.Files.walk(Files.java:3911) ~[?:?]
	at java.base/java.nio.file.Files.walk(Files.java:3966) ~[?:?]
	at polarpaper-1.21.8.4.jar/live.minehub.polarpaper.PolarPaper.onDisable(PolarPaper.java:74) ~[polarpaper-1.21.8.4.jar:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:286) ~[paper-api-1.21.8-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugin(PaperPluginInstanceManager.java:237) ~[paper-1.21.8.jar:1.21.8-60-29c8822]
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugins(PaperPluginInstanceManager.java:161) ~[paper-1.21.8.jar:1.21.8-60-29c8822]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.disablePlugins(PaperPluginManagerImpl.java:97) ~[paper-1.21.8.jar:1.21.8-60-29c8822]
	at org.bukkit.plugin.SimplePluginManager.disablePlugins(SimplePluginManager.java:541) ~[paper-api-1.21.8-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.CraftServer.disablePlugins(CraftServer.java:625) ~[paper-1.21.8.jar:1.21.8-60-29c8822]
	at net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:1002) ~[paper-1.21.8.jar:1.21.8-60-29c8822]
	at net.minecraft.server.dedicated.DedicatedServer.stopServer(DedicatedServer.java:712) ~[paper-1.21.8.jar:1.21.8-60-29c8822]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1296) ~[paper-1.21.8.jar:1.21.8-60-29c8822]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310) ~[paper-1.21.8.jar:1.21.8-60-29c8822]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]

</p>
</details> 