### PR TITLE
Fix save on stop on Folia

### DIFF
--- a/core/src/main/java/live/minehub/polarpaper/core/util/FoliaUtil.java
+++ b/core/src/main/java/live/minehub/polarpaper/core/util/FoliaUtil.java
@@ -7,15 +7,32 @@ import org.bukkit.plugin.Plugin;
 
 public class FoliaUtil {
 
-    public static void scheduleOnEntityIfFolia(Plugin plugin, Entity entity, Runnable runnable) {
-        if (isFolia()) {
-            entity.getScheduler().execute(plugin, runnable, null, 1L);
-        } else {
-            runnable.run();
+    /**
+     * Runs the task on the thread owning the entity
+     *
+     * @param retired Run instead of the task when the entity is gone and the task can no longer be executed
+     */
+    public static void scheduleOnEntityIfFolia(Plugin plugin, Entity entity, Runnable runnable, Runnable retired) {
+        if (ShutdownExecutor.isRunning()) {
+            ShutdownExecutor.execute(runnable);
+            return;
         }
+
+        if (!isFolia() || Bukkit.isOwnedByCurrentRegion(entity)) {
+            runnable.run();
+            return;
+        }
+
+        // execute returns false when the entity has been removed, in which case neither callback is run
+        if (!entity.getScheduler().execute(plugin, runnable, retired, 1L)) retired.run();
     }
 
     public static void scheduleOnRegionIfFolia(Plugin plugin, World world, int chunkX, int chunkZ, Runnable runnable) {
+        if (ShutdownExecutor.isRunning()) {
+            ShutdownExecutor.execute(runnable);
+            return;
+        }
+
         if (isFolia()) {
             Bukkit.getRegionScheduler().execute(plugin, world, chunkX, chunkZ, runnable);
         } else {

--- a/core/src/main/java/live/minehub/polarpaper/core/util/ShutdownExecutor.java
+++ b/core/src/main/java/live/minehub/polarpaper/core/util/ShutdownExecutor.java
@@ -1,0 +1,105 @@
+package live.minehub.polarpaper.core.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Runs tasks that would normally be handed to a region or entity scheduler on the thread that is stopping the server.
+ * <p>
+ * Plugins are disabled while the server is stopping, and a scheduler drops anything submitted by a plugin that is no
+ * longer enabled. Folia goes further and halts its region schedulers before it disables plugins, so a task scheduled
+ * from onDisable is never picked up and whatever waits on it blocks forever. Folia disables plugins from its region
+ * shutdown thread, which bypasses the region ownership checks (it is the same thread Folia saves its own chunks with),
+ * so those tasks can be run there instead.
+ */
+public final class ShutdownExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShutdownExecutor.class);
+
+    private static final Runnable WAKEUP = () -> {};
+
+    private static final BlockingQueue<Runnable> TASKS = new LinkedBlockingQueue<>();
+    private static volatile boolean running = false;
+
+    private ShutdownExecutor() {
+    }
+
+    /**
+     * Whether a thread is currently picking up the tasks given to {@link #execute(Runnable)}
+     */
+    public static boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Starts accepting tasks on the calling thread.
+     * <br>
+     * The caller is expected to run them through {@link #awaitCompletion} and to call {@link #stop()} when done
+     */
+    public static void start() {
+        running = true;
+    }
+
+    /**
+     * Stops accepting tasks and runs what is left over, so nothing waiting on a queued task stays blocked
+     */
+    public static void stop() {
+        running = false;
+
+        Runnable task;
+        while ((task = TASKS.poll()) != null) {
+            run(task);
+        }
+    }
+
+    /**
+     * Queues a task to be run by the thread stopping the server
+     */
+    public static void execute(Runnable task) {
+        TASKS.add(task);
+    }
+
+    /**
+     * Runs queued tasks on the calling thread until the given future completes
+     *
+     * @return false if the future did not complete within the timeout
+     */
+    public static boolean awaitCompletion(CompletableFuture<?> future, long timeout, TimeUnit unit) {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+
+        // the future is completed by whichever thread finishes the work, so wake the loop up rather than
+        // leaving it waiting on a queue that nothing is going to add to
+        future.whenComplete((_, _) -> TASKS.add(WAKEUP));
+
+        while (!future.isDone()) {
+            long remaining = deadline - System.nanoTime();
+            if (remaining <= 0) return false;
+
+            Runnable task;
+            try {
+                task = TASKS.poll(remaining, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+
+            if (task != null) run(task);
+        }
+
+        return true;
+    }
+
+    private static void run(Runnable task) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            LOGGER.error("Shutdown task failed: ", e);
+        }
+    }
+
+}

--- a/core/src/main/java/live/minehub/polarpaper/core/world/PolarChunk.java
+++ b/core/src/main/java/live/minehub/polarpaper/core/world/PolarChunk.java
@@ -231,27 +231,32 @@ public record PolarChunk(
 
         CompletableFuture<Void> future = new CompletableFuture<>();
         FoliaUtil.scheduleOnRegionIfFolia(worldAccess.getPlugin(), world, chunkX, chunkZ, () -> {
-            for (BlockPos blockPos : chunkAccess.getBlockEntitiesPos()) {
-                net.minecraft.world.level.block.entity.BlockEntity blockEntity = chunkAccess.getBlockEntity(blockPos);
+            try {
+                for (BlockPos blockPos : chunkAccess.getBlockEntitiesPos()) {
+                    net.minecraft.world.level.block.entity.BlockEntity blockEntity = getBlockEntity(chunkAccess, blockPos);
 
-                if (blockEntity == null) continue;
-                if (!blockSelector.test(blockPos.getX(), blockPos.getY(), blockPos.getZ())) continue;
+                    if (blockEntity == null) continue;
+                    if (!blockSelector.test(blockPos.getX(), blockPos.getY(), blockPos.getZ())) continue;
 
-                CompoundTag compoundTag = blockEntity.saveWithFullMetadata(registryAccess);
+                    CompoundTag compoundTag = blockEntity.saveWithFullMetadata(registryAccess);
 
-                Optional<String> id = compoundTag.getString("id");
-                if (id.isEmpty()) {
-                    LOGGER.warn("No ID in block entity data at: {}", blockPos);
-                    LOGGER.warn("Compound tag: {}", compoundTag);
-                    continue;
+                    Optional<String> id = compoundTag.getString("id");
+                    if (id.isEmpty()) {
+                        LOGGER.warn("No ID in block entity data at: {}", blockPos);
+                        LOGGER.warn("Compound tag: {}", compoundTag);
+                        continue;
+                    }
+
+                    int index = CoordConversion.chunkBlockIndex(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+                    polarBlockEntities.add(new BlockEntity(index, id.get(), compoundTag));
+                    blockEntities.put(blockPos, blockEntity);
                 }
 
-                int index = CoordConversion.chunkBlockIndex(blockPos.getX(), blockPos.getY(), blockPos.getZ());
-                polarBlockEntities.add(new BlockEntity(index, id.get(), compoundTag));
-                blockEntities.put(blockPos, blockEntity);
+                future.complete(null);
+            } catch (Exception e) {
+                // the future is what the rest of the conversion waits on, so it has to be completed either way
+                future.completeExceptionally(e);
             }
-
-            future.complete(null);
         });
 
         int[][] heightMaps = new int[PolarChunk.MAX_HEIGHTMAPS][0];
@@ -278,6 +283,20 @@ public record PolarChunk(
             LOGGER.error("Failed to convert chunk", e);
             return null;
         });
+    }
+
+    /**
+     * Reads a block entity out of a chunk that is being converted
+     * <p>
+     * While the server is stopping this goes straight to the chunk's own block entities. The captured block entities
+     * that {@link LevelChunk#getBlockEntity} looks at first live in region data on Folia, which the thread stopping
+     * the server cannot reach, and nothing is capturing block entities by then anyway
+     */
+    private static net.minecraft.world.level.block.entity.@Nullable BlockEntity getBlockEntity(ChunkAccess chunkAccess, BlockPos blockPos) {
+        if (ShutdownExecutor.isRunning() && chunkAccess instanceof LevelChunk levelChunk) {
+            return levelChunk.getBlockEntities().get(blockPos);
+        }
+        return chunkAccess.getBlockEntity(blockPos);
     }
 
     private static PolarSection convertSection(int chunkX, int chunkZ, LevelChunkSection chunkAccessSection, Registry<Biome> biomeRegistry, live.minehub.polarpaper.core.world.BlockSelector blockSelector, int minSection, int sectionI, @Nullable LevelLightEngine lightEngine) {

--- a/paper_26_1_2/src/main/java/live/minehub/polarpaper/paper_26_1/EntitySerializerImpl.java
+++ b/paper_26_1_2/src/main/java/live/minehub/polarpaper/paper_26_1/EntitySerializerImpl.java
@@ -61,14 +61,15 @@ public class EntitySerializerImpl implements EntitySerializer {
                 // saveAsPassenger sometimes calls events (e.g. VillagerAcquireTradeEvent), causing errors when called async so try again synchronously
                 CompletableFuture<Boolean> successfulFuture = new CompletableFuture<>();
 
-                entity.getScheduler().run(plugin, (t) -> {
+                FoliaUtil.scheduleOnEntityIfFolia(plugin, entity, () -> {
                     try {
                         boolean successful2 = ((CraftEntity) entity).getHandle().saveAsPassenger(tagValueOutput, true, false, false);
                         successfulFuture.complete(successful2);
                     } catch (Exception e2) {
                         LOGGER.error("Failed to serialize entity", e2);
+                        successfulFuture.complete(false);
                     }
-                }, null);
+                }, () -> successfulFuture.complete(false));
                 successful = successfulFuture.join();
             }
 
@@ -93,7 +94,7 @@ public class EntitySerializerImpl implements EntitySerializer {
             }
 
             byteArrayFuture.complete(outputStream.toByteArray());
-        });
+        }, () -> byteArrayFuture.complete(null));
 
         return byteArrayFuture;
     }

--- a/paper_latest/src/main/java/live/minehub/polarpaper/paper_latest/EntitySerializerImpl.java
+++ b/paper_latest/src/main/java/live/minehub/polarpaper/paper_latest/EntitySerializerImpl.java
@@ -62,14 +62,15 @@ public class EntitySerializerImpl implements EntitySerializer {
                 // saveAsPassenger sometimes calls events (e.g. VillagerAcquireTradeEvent), causing errors when called async so try again synchronously
                 CompletableFuture<Boolean> successfulFuture = new CompletableFuture<>();
 
-                entity.getScheduler().run(plugin, (t) -> {
+                FoliaUtil.scheduleOnEntityIfFolia(plugin, entity, () -> {
                     try {
                         boolean successful2 = ((CraftEntity) entity).getHandle().saveAsPassenger(tagValueOutput, true, false, false);
                         successfulFuture.complete(successful2);
                     } catch (Exception e2) {
                         LOGGER.error("Failed to serialize entity", e2);
+                        successfulFuture.complete(false);
                     }
-                }, null);
+                }, () -> successfulFuture.complete(false));
                 successful = successfulFuture.join();
             }
 
@@ -94,7 +95,7 @@ public class EntitySerializerImpl implements EntitySerializer {
             }
 
             byteArrayFuture.complete(outputStream.toByteArray());
-        });
+        }, () -> byteArrayFuture.complete(null));
 
         return byteArrayFuture;
     }

--- a/src/main/java/live/minehub/polarpaper/PolarPaper.java
+++ b/src/main/java/live/minehub/polarpaper/PolarPaper.java
@@ -8,6 +8,7 @@ import live.minehub.polarpaper.core.config.Config;
 import live.minehub.polarpaper.core.generator.PolarGenerator;
 import live.minehub.polarpaper.core.source.FilePolarSource;
 import live.minehub.polarpaper.core.util.FoliaUtil;
+import live.minehub.polarpaper.core.util.ShutdownExecutor;
 import live.minehub.polarpaper.util.WorldKey;
 import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
@@ -22,9 +23,18 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.stream.Stream;
 
 public final class PolarPaper extends JavaPlugin {
+
+    // A save should never hang now that its tasks are actually run, but a stop that never finishes is worse than
+    // a world that failed to save, so give up eventually. Folia allows itself the same 60s to halt its schedulers.
+    private static final long SAVE_ON_STOP_TIMEOUT_SECONDS = 60;
 
     @Override
     public void onEnable() {
@@ -73,41 +83,66 @@ public final class PolarPaper extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        for (World world : getServer().getWorlds()) {
-            PolarGenerator generator = PolarGenerator.fromWorld(world);
-            if (generator == null) continue;
+        // Saving schedules tasks that no scheduler is going to run anymore at this point, so they get run on this
+        // thread instead. Without this the save either blocks forever or quietly drops whatever it was waiting on.
+        ShutdownExecutor.start();
+        try {
+            for (World world : getServer().getWorlds()) {
+                PolarGenerator generator = PolarGenerator.fromWorld(world);
+                if (generator == null) continue;
 
-            Path worldFolderPath = world.getWorldFolder().toPath();
-            if (Files.exists(worldFolderPath)) {
-                getLogger().info("Clearing temp files for " + world.getKey().getKey());
-                try (Stream<Path> paths = Files.walk(worldFolderPath)) {
-                    paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-                } catch (IOException e) {
-                    getLogger().warning("Failed to delete temp files for " + world.getKey().getKey());
-                    StringWriter sw = new StringWriter();
-                    e.printStackTrace(new PrintWriter(sw));
-                    String exceptionAsString = sw.toString();
-                    getLogger().warning(exceptionAsString);
+                Path worldFolderPath = world.getWorldFolder().toPath();
+                if (Files.exists(worldFolderPath)) {
+                    getLogger().info("Clearing temp files for " + world.getKey().getKey());
+                    try (Stream<Path> paths = Files.walk(worldFolderPath)) {
+                        paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+                    } catch (IOException e) {
+                        getLogger().warning("Failed to delete temp files for " + world.getKey().getKey());
+                        StringWriter sw = new StringWriter();
+                        e.printStackTrace(new PrintWriter(sw));
+                        String exceptionAsString = sw.toString();
+                        getLogger().warning(exceptionAsString);
+                    }
                 }
-            }
 
-            if (!generator.getConfig().saveOnStop()) {
-                getLogger().info(String.format("Not saving '%s' as it has save on stop disabled", world.getKey().getKey()));
-                continue;
-            }
-            if (Polar.isLoading(world.getKey())) {
-                getLogger().info(String.format("Not saving '%s' as it was not fully loaded", world.getKey().getKey()));
-                continue;
-            }
+                if (!generator.getConfig().saveOnStop()) {
+                    getLogger().info(String.format("Not saving '%s' as it has save on stop disabled", world.getKey().getKey()));
+                    continue;
+                }
+                if (Polar.isLoading(world.getKey())) {
+                    getLogger().info(String.format("Not saving '%s' as it was not fully loaded", world.getKey().getKey()));
+                    continue;
+                }
 
-            getLogger().info("Saving '" + world.getKey().getKey() + "'...");
-
-            long before = System.nanoTime();
-            Polar.updateConfig(world, world.getKey().getKey());
-            Polar.saveWorld(world).join(); // TODO: does not work on Folia as it schedules tasks
-            int ms = (int) ((System.nanoTime() - before) / 1_000_000);
-            getLogger().info(String.format("Saved '%s' in %sms", world.getKey().getKey(), ms));
+                saveOnStop(world);
+            }
+        } finally {
+            ShutdownExecutor.stop();
         }
+    }
+
+    private void saveOnStop(World world) {
+        String worldName = world.getKey().getKey();
+        getLogger().info("Saving '" + worldName + "'...");
+
+        long before = System.nanoTime();
+        Polar.updateConfig(world, worldName);
+
+        CompletableFuture<Void> saveFuture = Polar.saveWorld(world);
+        if (!ShutdownExecutor.awaitCompletion(saveFuture, SAVE_ON_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            getLogger().severe(String.format("Gave up saving '%s' after %s seconds", worldName, SAVE_ON_STOP_TIMEOUT_SECONDS));
+            return;
+        }
+
+        try {
+            saveFuture.join();
+        } catch (CompletionException | CancellationException e) {
+            getLogger().log(Level.SEVERE, String.format("Failed to save '%s'", worldName), e);
+            return;
+        }
+
+        int ms = (int) ((System.nanoTime() - before) / 1_000_000);
+        getLogger().info(String.format("Saved '%s' in %sms", worldName, ms));
     }
 
     public static PolarPaper getPlugin() {


### PR DESCRIPTION
Closes #37.

## The problem

Saving a world schedules work on the region scheduler (block entities, in `PolarChunk.convert`) and on the entity scheduler (`EntitySerializerImpl.entityToBytes`), then blocks on the resulting futures. That is fine while the server is running, but not from `onDisable`:

* Folia disables plugins from its region shutdown thread, and it gets there only after `TickRegions.getScheduler().halt(...)` has stopped every region thread. Nothing is left to run a region task.
* Bukkit drops any task submitted by a plugin that is not enabled, and `JavaPlugin.setEnabled` flips `isEnabled` to false *before* it calls `onDisable`. `FoliaEntityScheduler` checks `plugin.isEnabled()` inside the task wrapper and returns early, so this part is not Folia specific.

So the tasks never ran, the futures never completed, and `Polar.saveWorld(world).join()` blocked forever. The world was not saved and the server never finished stopping, which is what the TODO on that line was about.

Reproduced on Folia 26.2 (build 4) with a blank polar world containing one loaded chunk. `/stop` prints `Saving 'testworld'...` and then nothing, forever:

```
"Region shutdown thread" #86 waiting on condition
	at java.util.concurrent.CompletableFuture.join(CompletableFuture.java:2138)
	at live.minehub.polarpaper.PolarPaper.onDisable(PolarPaper.java:107)
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:285)
	...
	at net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:1091)
	at io.papermc.paper.threadedregions.RegionShutdownThread.run(RegionShutdownThread.java:163)
```

## The fix

`ShutdownExecutor` is a small queue that the stopping thread drains itself. While it is running, `FoliaUtil` hands tasks to it instead of to a scheduler, and `onDisable` runs the queue until the save future completes.

Doing the work on that thread is safe. Folia's `TickThread.isTickThreadFor(...)` falls back to `isShutdownThread()` when there is no current region, so the ownership checks pass. It is the same thread Folia saves its own chunks with a moment later. On Paper the stopping thread is just the main thread, so nothing changes there.

One thing does not survive the move: `LevelChunk.getBlockEntity` looks at the captured block entities first, and on Folia those live in region data that the shutdown thread cannot reach (`getCurrentWorldData()` returns null there). Block entities are only ever captured mid block placement, so while stopping the conversion reads the chunk's own block entity map instead.

## Other hangs on the same path

Both of these could block a save forever on their own, so they are fixed here too:

* `EntityScheduler.execute` returns false when the entity has already been removed, and then runs neither the task nor the retired callback. `scheduleOnEntityIfFolia` passed `null` for retired and ignored the return value, so `entityToBytes` left its future uncompleted and `EntitiesWorldAccess.saveChunkData` blocked on `join()`. It now takes a retired callback and invokes it when scheduling fails.
* The `saveAsPassenger` retry left `successfulFuture` uncompleted when the retry itself threw, and it scheduled onto the entity from the entity's own thread on Folia, which deadlocks against itself. It now goes through `scheduleOnEntityIfFolia`, which runs inline when the caller already owns the entity.

The block entity task in `PolarChunk.convert` also completes its future exceptionally now rather than leaving it hanging if the loop throws.

## Timeout

Saving on stop is bounded by `SAVE_ON_STOP_TIMEOUT_SECONDS` (60s, the same budget Folia gives itself to halt its schedulers). It should not be reachable now that the tasks actually run, but a stop that never returns is worse than a world that failed to save. Happy to change the number or drop it if you would rather it stayed unbounded.

## Testing

Blank polar world with a force loaded chunk, a chest, a furnace and a cow, `saveOnStop: true`, then `/stop`.

Folia 26.2 build 4:

```
[polarpaper] Disabling polarpaper v2.1.3
[polarpaper] Clearing temp files for testworld
[polarpaper] Saving 'testworld'...
[polarpaper] Saved 'testworld' in 19ms
```

Paper 26.2 build 112, same setup, as a check that the normal path is unaffected:

```
[polarpaper] Saving 'testworld'...
[polarpaper] Saved 'testworld' in 27ms
```

No errors in either, shutdown continues normally and the server exits. Before the change the Folia run never gets past `Saving 'testworld'...`.

Decompressing the two written files gives byte identical content, with the block entities and the entity present:

```
minecraft:chest    x3
minecraft:furnace  x3
minecraft:cow      x1
```

The file also loads again on the next start (`Loading polar world: testworld`).
